### PR TITLE
fix inconsistent algo name, enable the wallet stored at browser

### DIFF
--- a/src/app/home/views/home/home.component.ts
+++ b/src/app/home/views/home/home.component.ts
@@ -139,7 +139,7 @@ export class HomeComponent implements OnInit {
         };
         accounts.push({
           address: wallet.address.plain(),
-          algo: ProximaxProvider.getWalletAlgorithm().Pass_bip32,
+          algo: "pass:bip32",
           brain: true,
           default: (index === 0),
           encrypted: wallet.encryptedPrivateKey.encryptedKey,

--- a/src/app/wallet/services/wallet.service.ts
+++ b/src/app/wallet/services/wallet.service.ts
@@ -200,7 +200,7 @@ export class WalletService {
    */
   buildAccount(data: any): AccountsInterface {
     return {
-      algo: ProximaxProvider.getWalletAlgorithm().Pass_bip32,
+      algo: "pass:bip32",
       address: data.address,
       brain: true,
       default: data.byDefault,
@@ -422,7 +422,17 @@ export class WalletService {
     // console.log(acct, common);
     try {
       if (acct && common && acct.encrypted !== '') {
-        if (!Crypto.passwordToPrivateKey(common, acct, alg)) {
+
+        var algo = null;
+
+        if(alg === "pass:bip32"){
+          algo = ProximaxProvider.getWalletAlgorithm().Pass_bip32;
+        }
+        else{
+          algo = alg;
+        }
+
+        if (!Crypto.passwordToPrivateKey(common, acct, algo)) {
           this.sharedService.showError('', 'Invalid password');
           return false;
         }
@@ -1182,7 +1192,7 @@ export interface TransactionsNis1Interface {
 
 export interface AccountsInterface {
   address: string;
-  algo: number;
+  algo: string;
   brain: boolean;
   default: boolean;
   encrypted: string;

--- a/src/app/wallet/views/selection-wallet-creation-type/selection-wallet-creation-type.component.ts
+++ b/src/app/wallet/views/selection-wallet-creation-type/selection-wallet-creation-type.component.ts
@@ -87,7 +87,7 @@ export class SelectionWalletCreationTypeComponent implements OnInit {
           };
           accounts.push({
             address: wallet.address.plain(),
-            algo: ProximaxProvider.getWalletAlgorithm().Pass_bip32,
+            algo: "pass:bip32",
             brain: true,
             default: (index === 0),
             encrypted: wallet.encryptedPrivateKey.encryptedKey,


### PR DESCRIPTION
- fix inconsistent algo name, enable the wallet stored at browser
- use the previous algo name to store at browser